### PR TITLE
Add support for Xcode 6

### DIFF
--- a/Add-Lua.sh
+++ b/Add-Lua.sh
@@ -79,4 +79,4 @@ cp "$SCRIPT_PATH/Lua.xclangspec" "$DVTFOUNDATION_PATH"
 
 # Remove any cached Xcode plugins
 #
-rm -f /private/var/folders/*/*/*/com.apple.DeveloperTools/*/Xcode/PlugInCache.xcplugincache
+rm -f /private/var/folders/*/*/*/com.apple.DeveloperTools/*/Xcode/PlugInCache*.xcplugincache


### PR DESCRIPTION
Accommodate new naming convention for plug-in cache files under Xcode 6. Should still work for earlier versions of Xcode.
Fixes issue #4 .
